### PR TITLE
Update minimum version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Release Date: 24th June, 2022
 
 * Updated: Action Scheduler library to v3.4.2.
 * Fixed: Various bugs and PHP errors.
+* Minimum WordPress supported version is now 5.2.0.
 * Tested with WordPress 6.0.
 
 ## 1.0.5

--- a/includes/Base/AdminNotice.php
+++ b/includes/Base/AdminNotice.php
@@ -36,10 +36,10 @@ class AdminNotice extends BaseController
 		global $wp_version;
 
 		// Show a warning to sites running PHP < 5.6
-		if ( version_compare( $wp_version, '5.1.0', '<' ) ) {
+		if ( version_compare( $wp_version, '5.2.0', '<' ) ) {
 			deactivate_plugins( $this->plugin );
 			/* translators: %s: Plugin Name */
-			echo '<div class="error"><p>' . sprintf( __( 'Your version of WordPress is below the minimum version of WordPress required by %s plugin. Please upgrade WordPress to 5.1.0 or later.', 'migrate-wp-cron-to-action-scheduler' ), $this->name ) . '</p></div>';
+			echo '<div class="error"><p>' . sprintf( __( 'Your version of WordPress is below the minimum version of WordPress required by %s plugin. Please upgrade WordPress to 5.2.0 or later.', 'migrate-wp-cron-to-action-scheduler' ), $this->name ) . '</p></div>';
 		    return;
 		}
 		

--- a/includes/Core/MigrateActions.php
+++ b/includes/Core/MigrateActions.php
@@ -36,7 +36,7 @@ class MigrateActions
 	 */
 	public function migrate_old_crons() {
         global $wp_version;
-        if ( version_compare( $wp_version, '5.1.0', '<' ) ) {
+        if ( version_compare( $wp_version, '5.2.0', '<' ) ) {
             return;
         }
 
@@ -70,7 +70,7 @@ class MigrateActions
 	 */
     public function regenerate_crons() {
         global $wpdb, $wp_version;
-        if ( version_compare( $wp_version, '5.1.0', '<' ) ) {
+        if ( version_compare( $wp_version, '5.2.0', '<' ) ) {
             return;
         }
 

--- a/languages/migrate-wp-cron-to-action-scheduler.pot
+++ b/languages/migrate-wp-cron-to-action-scheduler.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-06-24T11:47:00+00:00\n"
+"POT-Creation-Date: 2022-06-24T11:50:41+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.5.0\n"
 "X-Domain: migrate-wp-cron-to-action-scheduler\n"
@@ -52,7 +52,7 @@ msgstr ""
 
 #. translators: %s: Plugin Name
 #: includes/Base/AdminNotice.php:42
-msgid "Your version of WordPress is below the minimum version of WordPress required by %s plugin. Please upgrade WordPress to 5.1.0 or later."
+msgid "Your version of WordPress is below the minimum version of WordPress required by %s plugin. Please upgrade WordPress to 5.2.0 or later."
 msgstr ""
 
 #. translators: %s: Plugin Name

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,7 @@ Release Date: 24th June, 2022
 
 * Updated: Action Scheduler library to v3.4.2.
 * Fixed: Various bugs and PHP errors.
+* Minimum WordPress supported version is now 5.2.0.
 * Tested with WordPress 6.0.
 
 = 1.0.5 =


### PR DESCRIPTION
* Minimum WordPress supported version is now 5.2.0.